### PR TITLE
update: use 'Union' instead of '|' for function return type annotation

### DIFF
--- a/shbus/realtime.py
+++ b/shbus/realtime.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Union
 
 from shbus import __ALL_LINES__, utils
 from shbus.models import LineSequence
@@ -10,7 +10,7 @@ def get_all_lines() -> List[str]:
 
 
 def get_realtime_bus(lines: List[LineSequence]) -> List[
-    Response_pb2.Dispatch | Response_pb2.Monitor | Response_pb2.Error]:
+    Union[Response_pb2.Dispatch, Response_pb2.Monitor, Response_pb2.Error]]:
     targets = list()
     for line in lines:
         target = Request_pb2.Sequence()


### PR DESCRIPTION
将函数 `get_realtime_bus` 的返回类型 List 中的 `|` 运算符改为 Union，以定义一个包含多个类型的联合类型。以防止在 Python 3.9+ 中使用时出现 TypeError: unsupported operand type(s) for |: 'google._upb._message.MessageMeta' and 'google._upb._message.MessageMeta' 错误。